### PR TITLE
PREAPPS-391: 'Then Move the messages to this folder' not functional at the filters settings screen.

### DIFF
--- a/src/components/folder-select/index.js
+++ b/src/components/folder-select/index.js
@@ -1,6 +1,7 @@
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import debounce from 'lodash-es/debounce';
 import flatten from 'lodash-es/flatten';
 import findIndex from 'lodash-es/findIndex';
 import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed';
@@ -97,7 +98,7 @@ export default class FolderSelect extends Component {
 		keyboardSelection: null // [<groupIndex>, <itemIndex>]
 	};
 
-	handleFilterChange = (e, folders) => {
+	handleFilterChange = debounce((e, folders) => {
 		const value = e.target.value;
 		const newFolderGroups = [filteredFolders(folders, value)];
 		const newSelection = value === ''
@@ -108,7 +109,7 @@ export default class FolderSelect extends Component {
 			filterValue: value,
 			keyboardSelection: newSelection
 		});
-	}
+	}, 100)
 
 	handleFilterKeydown = (e) => {
 		if (e.keyCode === KeyCodes.DOWN_ARROW || e.keyCode === KeyCodes.UP_ARROW) {

--- a/src/components/folder-select/index.js
+++ b/src/components/folder-select/index.js
@@ -109,7 +109,7 @@ export default class FolderSelect extends Component {
 			filterValue: value,
 			keyboardSelection: newSelection
 		});
-	}, 100)
+	}, 225)
 
 	handleFilterKeydown = (e) => {
 		if (e.keyCode === KeyCodes.DOWN_ARROW || e.keyCode === KeyCodes.UP_ARROW) {

--- a/src/components/settings/filters-settings/filter-modal/filter-modal-content.js
+++ b/src/components/settings/filters-settings/filter-modal/filter-modal-content.js
@@ -1,6 +1,5 @@
 import { Component, h } from 'preact';
 import { Text } from 'preact-i18n';
-import { connect } from 'preact-redux';
 import style from './style.less';
 import cx from 'classnames';
 import get from 'lodash-es/get';
@@ -11,7 +10,8 @@ import findIndex from 'lodash-es/findIndex';
 import merge from 'lodash-es/merge';
 import has from 'lodash-es/has';
 import cloneDeep from 'lodash-es/cloneDeep';
-import { getFolders } from '../../../../store/folders/selectors';
+import { withProps } from 'recompose';
+import getMailFolders from '../../../../graphql-decorators/get-mail-folders';
 import {
 	FILTER_TEST_TYPE,
 	FILTER_CONDITION_DISPLAY,
@@ -110,16 +110,12 @@ const FILTER_CONDITIONS_CONFIG = [
 	}
 ];
 
-@connect(
-	(state) => {
-		const folders = getFolders(state, 'message') || [];
-		return {
-			folders: folders
-				.filter((folder) => folder.absFolderPath)
-				.map(({ absFolderPath }) => normalizePath(absFolderPath))
-		};
-	}
-)
+@getMailFolders()
+@withProps(({ folders }) => ({
+	folders: folders
+		.filter((folder) => folder.absFolderPath)
+		.map(({ absFolderPath }) => normalizePath(absFolderPath))
+}))
 export default class FilterModalContent extends Component {
 	onRulePredicateChange = rulePath => ev => {
 		const value = cloneDeep(this.props.value);

--- a/src/components/settings/filters-settings/filter-modal/filter-modal-content.js
+++ b/src/components/settings/filters-settings/filter-modal/filter-modal-content.js
@@ -10,6 +10,7 @@ import findIndex from 'lodash-es/findIndex';
 import merge from 'lodash-es/merge';
 import has from 'lodash-es/has';
 import cloneDeep from 'lodash-es/cloneDeep';
+import { flattenFolders } from '../../../../utils/folders';
 import { withProps } from 'recompose';
 import getMailFolders from '../../../../graphql-decorators/get-mail-folders';
 import {
@@ -112,7 +113,7 @@ const FILTER_CONDITIONS_CONFIG = [
 
 @getMailFolders()
 @withProps(({ folders }) => ({
-	folders: folders
+	folders: flattenFolders(folders)
 		.filter((folder) => folder.absFolderPath)
 		.map(({ absFolderPath }) => normalizePath(absFolderPath))
 }))

--- a/src/utils/folders.js
+++ b/src/utils/folders.js
@@ -88,10 +88,10 @@ export function renamedFolderAbsPath(prevAbsPath, newName) {
 }
 
 export function flattenFolders(folders) {
-	return flatMapDeep(folders, (f => f.folder
-		? [{ ...f, folder: undefined }, flattenFolders(f.folder)]
-		: [f]
-	));
+	return flatMapDeep(folders, (f => ([
+		f,
+		...(f.folders ? flattenFolders(f.folders) : [])
+	])));
 }
 
 export function filteredFolders(folders, query) {


### PR DESCRIPTION
> PREAPPS-391: 'Then Move the messages to this folder' not functional at the filters settings screen.
> Steps:
> 1.Go to web client and login
> 2.Go to settings and then fIlters
> 3.Tap on add and go to 'then move messages to this folder' field. Click on it
>
> Actual : Nothing happens
> Expected: It should show the user with the folders available in the mailbox.

Now that the entities are not populated by the page load, the folders never make it into the `store` and never load in the dropdown. Changing the implementation to `graphql` fixes the problem.