### PR TITLE
PREAPPS-519: changed rules and border colors

### DIFF
--- a/src/components/contacts/style.less
+++ b/src/components/contacts/style.less
@@ -297,7 +297,7 @@
 	}
 
 	.header {
-		border-bottom: 1px solid @gray-darkest;
+		border-bottom: 1px solid @gray-lighter;
 		padding: 14px 24px;
 		margin: 0;
 
@@ -338,7 +338,7 @@
 		width: 100%;
 		height: 64px;
 		padding: 0 20px;
-		background: @off-white;
+		background: @body-bg;
 		border-top: 1px solid @gray-lighter;
 		line-height: 64px;
 	}
@@ -436,23 +436,19 @@
 				font-size: 13px;
 				padding: 9px 8px 8px;
 				width: 216px;
-				border: 1px solid @gray-darkest;
-				border-radius: 2px;
 				transition: box-shadow 300ms ease;
-				outline: none;
-				box-shadow: inset 0 -1px 0 -.5px @gray-lighter;
+				border: 1px solid @gray-lighter;
+				border-radius: 3px;
+				transition: border 300ms ease;
+				appearance: none;
 				cursor: text;
-
-				&:focus {
-					box-shadow: inset 0 -2px 0 @brand-tertiary;
-				}
 			}
 			textarea {
 				height: 64px;
 				resize: none;
 			}
 			.errorField {
-				border: 1px solid #cf2a2a;
+				border: 1px solid @brand-danger;
 				box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.3);
 			}
 


### PR DESCRIPTION
Changed rules and input borders to use @gray-lighter. Removed extra styling on focus. Now matches Settings focus state and border color. Also changed error style to @brand-danger rather than a hex value.