### PR TITLE
Added new utility for injecting the mail

### DIFF
--- a/tests/e2e/testcafe/utils/Inject-msg.js
+++ b/tests/e2e/testcafe/utils/Inject-msg.js
@@ -1,0 +1,36 @@
+/*eslint no-mixed-spaces-and-tabs: ["off", "smart-tabs"]*/
+import { profile } from '../profile/profile';
+import { soap } from './soap-client';
+let request = require('request');
+let fs = require('fs');
+
+export default class Inject {
+
+	async send(userAuth, filename) {
+		let cookie = request.cookie(`ZM_AUTH_TOKEN=${userAuth}`);
+		// Set the headers for the request
+		let headers = {
+			'Content-Type': 'multipart/form-data; charset=UTF-8',
+			Cookie: cookie
+		};
+		let options = {
+			url: `https://${profile.serverName}/service/upload`,
+			method: 'POST',
+			headers,
+			formData: {
+				'upload-file': fs.createReadStream(filename)
+			}
+		};
+		let attachmentID = null;
+		request(options, (error, response, body) => {
+			if (!error && response.statusCode === 200) {
+				// Print out the response body
+				attachmentID = body.substr(body.indexOf('null')+7,body.lastIndexOf(');') - (body.indexOf('null')+8));
+				soap.addMessage(userAuth,attachmentID);
+			}
+			else {
+				throw new Error('Error occured in uploading the file' + error);
+			}
+		});
+	}
+}

--- a/tests/e2e/testcafe/utils/soap-client.js
+++ b/tests/e2e/testcafe/utils/soap-client.js
@@ -482,6 +482,15 @@ class SoapClient {
 		}
 	}
 
+	async addMessage(userAuthToken, attachmentId) {
+
+		let requestObj =
+			`<AddMsgRequest xmlns='urn:zimbraMail'>
+			<m l='Inbox' f='u' aid='${attachmentId}'></m>
+			</AddMsgRequest>`;
+
+		await this.soapSend(userAuthToken,requestObj);
+	}
 }
 
 export let soap = new SoapClient();


### PR DESCRIPTION
As per requirement, I have added new utility "Inject-msg.js" to injecting the mail using  SOAP AddMsgRequest API. 

Uses:
import Inject from './utils/Inject-msg';
test('sample example', t=>{

t.ctx.user = await soap.createAccount(t.fixtureCtx.adminAuthToken);
t.ctx.userAuth = await soap.getUserAuthToken(t.ctx.user.email, t.ctx.user.password);
const inject = new Inject();
inject.send(t.ctx.userAuth, './data/mime/emails/single-inline-attachment.txt');
});