### PR TITLE
PREAPPS-264 Add sort by unread and size options to mail header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       "integrity": "sha512-aDvGDAHcVfUqNmd8q4//cHAP+HGxsbChbBbuk3+kMVk5TTxfWLpQWvVN3+UPjohLnwMYN7jr6BWNn2cYNqdm7g=="
     },
     "@zimbra/api-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@zimbra/api-client/-/api-client-0.1.2.tgz",
-      "integrity": "sha512-U33nzrNyB+vU6WB+GQuR4RALxUzn+3Py9gcQJ9oGnTQMb9R79HhTD6QS8t+H2IMfNQ7Yr1JH1nnK/+MCtPrWSg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@zimbra/api-client/-/api-client-1.0.0.tgz",
+      "integrity": "sha512-5Iq4Hq99aH6WtUJnn9vT1WI0QEGJqlBYx2q+XZKzROT/05upMhs9FK/vsVfhEPqaAdt4znxO1zb+uFkvyOBemg==",
       "requires": {
         "apollo-cache-inmemory": "1.1.12",
         "apollo-link": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15007,9 +15007,9 @@
       }
     },
     "testcafe-reporter-html-testrail": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-html-testrail/-/testcafe-reporter-html-testrail-1.0.8.tgz",
-      "integrity": "sha512-60a1OrBcPSLyFTw9wP3l4OxCSOlAHJqBHT/h2puSTqm/UT19bMh7LYMatzU3Cx4lIJOc3MIjpKsZluLLz7MOjg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-html-testrail/-/testcafe-reporter-html-testrail-2.0.0.tgz",
+      "integrity": "sha512-88nXLtI1SoinsV5HtP330IwwozVJ3LO0GI9cju9Nd6Lz1GWSwzrjvX04KzOMl6+eUQa0oIhsfw9ACmmxDj28zw==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "xml2js": "^0.4.19"
   },
   "dependencies": {
-    "@zimbra/api-client": "^0.1.2",
+    "@zimbra/api-client": "^1.0.0",
     "@zimbra/x-ui": "^1.0.1",
     "apollo-client": "^2.2.8",
     "choose-files": "^1.0.1",

--- a/src/components/action-menu-mail-sort/index.js
+++ b/src/components/action-menu-mail-sort/index.js
@@ -30,7 +30,9 @@ const SortActionMenuItem = ({ sort, sortBy, onSort, children }) => (
 	flagDescLabel: 'mail.sortLabels.flagDesc',
 	nameAscLabel: 'mail.sortLabels.nameAsc',
 	subjAscLabel: 'mail.sortLabels.subjAsc',
-	unreadLabel: 'mail.sortLabels.unread'
+	readDescLabel: 'mail.sortLabels.readDesc',
+	sizeAscLabel: 'mail.sortLabels.sizeAsc',
+	sizeDescLabel: 'mail.sortLabels.sizeDesc'
 })
 @connect(
 	state => ({
@@ -59,8 +61,14 @@ export default class ActionMenuMailSort extends Component {
 						<SortActionMenuItem {...props} sort={SORT_BY.dateAsc}>
 							<Text id="mail.sortMenu.dateAsc" />
 						</SortActionMenuItem>
-						<SortActionMenuItem {...props} sort={SORT_BY.unread}>
-							<Text id="mail.sortMenu.unread" />
+						<SortActionMenuItem {...props} sort={SORT_BY.readDesc}>
+							<Text id="mail.sortMenu.readDesc" />
+						</SortActionMenuItem>
+						<SortActionMenuItem {...props} sort={SORT_BY.sizeDesc}>
+							<Text id="mail.sortMenu.sizeDesc" />
+						</SortActionMenuItem>
+						<SortActionMenuItem {...props} sort={SORT_BY.sizeAsc}>
+							<Text id="mail.sortMenu.sizeAsc" />
 						</SortActionMenuItem>
 						<SortActionMenuItem {...props} sort={SORT_BY.attachDesc}>
 							<Text id="mail.sortMenu.attachDesc" />

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -46,8 +46,7 @@ import accountInfo from '../../graphql-decorators/account-info';
 import {
 	createZimbraSchema,
 	LocalBatchLink,
-	ZimbraInMemoryCache,
-	ZimbraErrorLink
+	ZimbraInMemoryCache
 } from '@zimbra/api-client';
 
 import { IntlProvider, Text } from 'preact-i18n';
@@ -137,7 +136,7 @@ export default class Provide extends Component {
 		});
 		const apolloClient = new ApolloClient({
 			cache,
-			link: ZimbraErrorLink.concat(link)
+			link
 		});
 
 		return (

--- a/src/components/mail-list-item/style.less
+++ b/src/components/mail-list-item/style.less
@@ -140,8 +140,15 @@
 		text-align: right;
 	}
 
-	&.wide time {
-		min-width: 80px;
+	&.wide {
+
+		time {
+			min-width: 80px;
+		}
+
+		.size {
+			min-width: 55px;
+		}
 	}
 
 	.indicators {

--- a/src/components/mail-list-item/wide.js
+++ b/src/components/mail-list-item/wide.js
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { Text } from 'preact-i18n';
 import cx from 'classnames';
 import prettyBytes from 'pretty-bytes';
-
+import get from 'lodash/get';
 import { Icon } from '@zimbra/blocks';
 import UnreadControl from '../unread-control';
 import MailInlineActionControl from '../mail-inline-action-control';
@@ -36,7 +36,15 @@ const WideListItem = ({
 }) => {
 
 
-	let messageOrConvSize = showSize && <span class={s.size}>{prettyBytes(+item.sortField)}</span>;
+	let messageOrConvSize;
+	if (showSize) {
+		let size = +item.sortField || +item.size;
+		if (!size) {
+			size = (get(item, 'messages') || []).reduce((max, { size: sz }) => Math.max(max,+sz), 0);
+		}
+		messageOrConvSize = <span class={s.size}>{prettyBytes(size)}</span>;
+	}
+
 
 	return (
 		<div class={s.wideListItem}>

--- a/src/components/mail-list-item/wide.js
+++ b/src/components/mail-list-item/wide.js
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { Text } from 'preact-i18n';
 import cx from 'classnames';
+import prettyBytes from 'pretty-bytes';
 
 import { Icon } from '@zimbra/blocks';
 import UnreadControl from '../unread-control';
@@ -22,6 +23,7 @@ const WideListItem = ({
 	isSelected,
 	isUnread,
 	isUrgent,
+	showSize,
 	onCheckbox,
 	onInlineDelete,
 	onToggleFlagged,
@@ -31,73 +33,80 @@ const WideListItem = ({
 	showFolderName,
 	showSnippet,
 	disableInlineSearch
-}) => (
-	<div class={s.wideListItem}>
-		<input
-			aria-label="Select Email"
-			type="checkbox"
-			checked={isSelected}
-			onClick={onCheckbox}
-			onDblClick={stopPropagation}
-			class={s.wideCheckbox}
-		/>
-		<UnreadControl
-			class={s.unreadControl}
-			onChange={onToggleUnread}
-			value={isUnread}
-		/>
-		<div class={s.wideListItemSenderCol}>
-			<div class={s.wideListItemSender}>
-				{emailAddresses.join(', ')}
-				{isDraft && (
-					<span>
-						{emailAddresses.length > 0 ? ', ' : ''}
-						<span class={s.draft}>
-							<Text id="mail.DRAFT" />
+}) => {
+
+
+	let messageOrConvSize = showSize && <span class={s.size}>{prettyBytes(+item.sortField)}</span>;
+
+	return (
+		<div class={s.wideListItem}>
+			<input
+				aria-label="Select Email"
+				type="checkbox"
+				checked={isSelected}
+				onClick={onCheckbox}
+				onDblClick={stopPropagation}
+				class={s.wideCheckbox}
+			/>
+			<UnreadControl
+				class={s.unreadControl}
+				onChange={onToggleUnread}
+				value={isUnread}
+			/>
+			<div class={s.wideListItemSenderCol}>
+				<div class={s.wideListItemSender}>
+					{emailAddresses.join(', ')}
+					{isDraft && (
+						<span>
+							{emailAddresses.length > 0 ? ', ' : ''}
+							<span class={s.draft}>
+								<Text id="mail.DRAFT" />
+							</span>
 						</span>
-					</span>
-				)}
-			</div>
-			<div>
-				{!disableInlineSearch && (
+					)}
+				</div>
+				<div>
+					{!disableInlineSearch && (
+						<MailInlineActionControl
+							name="search"
+							className={s.inlineControl}
+							onChange={onInlineSearch}
+						/>
+					)}
 					<MailInlineActionControl
-						name="search"
+						name="trash"
 						className={s.inlineControl}
-						onChange={onInlineSearch}
+						onChange={onInlineDelete}
 					/>
-				)}
-				<MailInlineActionControl
-					name="trash"
-					className={s.inlineControl}
-					onChange={onInlineDelete}
-				/>
-				<MailInlineActionControl
-					name="star"
-					className={s.inlineControl}
-					activeClassName={s.starred}
-					value={isFlagged}
-					onChange={onToggleFlagged}
-				/>
+					<MailInlineActionControl
+						name="star"
+						className={s.inlineControl}
+						activeClassName={s.starred}
+						value={isFlagged}
+						onChange={onToggleFlagged}
+					/>
+				</div>
+			</div>
+			<div class={s.wideListItemSubject}>
+				<h4 class={cx(s.subject, s.wideSubject)} title={item.subject}>
+					{item.subject || <Text id="mail.noSubject" />}
+					{count && count > 1 ? <span> ({count})</span> : null}
+				</h4>
+			</div>
+			<div class={cx(s.excerpt, s.wideExcerpt)}>
+				{(showSnippet && item.excerpt) || ' '}
+			</div>
+
+			{showFolderName && item.folder && <div>{item.folder.name}</div>}
+
+			<div class={s.wideListItemTimeCol}>
+				{isUrgent && <span class={s.urgent}>🚩</span>}
+				{isAttachment && <Icon class={s.attachment} name="paperclip" />}
+				{messageOrConvSize}
+				<EmailTime time={item.date} />
 			</div>
 		</div>
-		<div class={s.wideListItemSubject}>
-			<h4 class={cx(s.subject, s.wideSubject)} title={item.subject}>
-				{item.subject || <Text id="mail.noSubject" />}
-				{count && count > 1 ? <span> ({count})</span> : null}
-			</h4>
-		</div>
-		<div class={cx(s.excerpt, s.wideExcerpt)}>
-			{(showSnippet && item.excerpt) || ' '}
-		</div>
-
-		{showFolderName && item.folder && <div>{item.folder.name}</div>}
-
-		<div class={s.wideListItemTimeCol}>
-			{isUrgent && <span class={s.urgent}>🚩</span>}
-			{isAttachment && <Icon class={s.attachment} name="paperclip" />}
-			<EmailTime time={item.date} />
-		</div>
-	</div>
-);
+	);
+};
 
 export default WideListItem;

--- a/src/components/mail-list/index.js
+++ b/src/components/mail-list/index.js
@@ -115,6 +115,7 @@ export default class MailList extends Component {
 										onCheckboxSelect={handleItemCheckboxSelect}
 										showSnippet={showSnippets}
 										density={messageListDensity}
+										showSize={sortBy.indexOf('size') === 0}
 									/>
 								))}
 							</div>

--- a/src/constants/search.js
+++ b/src/constants/search.js
@@ -5,7 +5,9 @@ export const SORT_BY = {
 	flagDesc: 'flagDesc', // is flagged / starred
 	nameAsc: 'nameAsc', // from address / sender
 	subjAsc: 'subjAsc', // subject
-	unread: 'unread'
+	readDesc: 'readDesc',
+	sizeAsc: 'sizeAsc',
+	sizeDesc: 'sizeDesc'
 };
 export const DEFAULT_SORT = SORT_BY.dateDesc;
 export const DEFAULT_LIMIT = 100;

--- a/src/intl.json
+++ b/src/intl.json
@@ -145,7 +145,9 @@
 			"subjAsc": "Subject",
 			"groupByConversations": "Group by Conversations",
 			"settings": "More Settings…",
-			"unread": "Unread"
+			"readDesc": "Unread",
+			"sizeAsc": "Size: Smallest on top",
+			"sizeDesc": "Size: Biggest on top"
 		},
 		"sortLabels": {
 			"dateDesc": "Sort by date",
@@ -154,7 +156,9 @@
 			"flagDesc": "Sort by starred",
 			"nameAsc": "Sort by sender",
 			"subjAsc": "Sort by subject",
-			"unread": "Sort by unread"
+			"readDesc": "Sort by unread",
+			"sizeAsc": "Sort by size",
+			"sizeDesc": "Sort by size"
 		},
 		"viewer": {
 			"messageContainsExternalImages": "This message contains external images",


### PR DESCRIPTION
Dependent on https://github.com/Zimbra/zm-api-js-client/pull/7 being released as a new version before this can be pushed.  

Also adds the message size to the mail item view when the preview pane is off or on the bottom.

[![https://gyazo.com/70f291b00ff7bfaaa99a3050ad6ce8d1](https://i.gyazo.com/70f291b00ff7bfaaa99a3050ad6ce8d1.gif)](https://gyazo.com/70f291b00ff7bfaaa99a3050ad6ce8d1)