### PR TITLE
Fix insecure form warnings by password managers

### DIFF
--- a/src/components/login/index.js
+++ b/src/components/login/index.js
@@ -148,7 +148,7 @@ export default class Login extends Component {
 							onError={this.handleError}
 						/>
 					) : (
-						<form onSubmit={this.submit} action="javascript:">
+						<form onSubmit={this.submit} action="javascript:" method="POST">
 							<div class={style.form}>
 
 								<label

--- a/src/components/login/reset-password-form.js
+++ b/src/components/login/reset-password-form.js
@@ -51,7 +51,7 @@ export default class ResetPasswordForm extends Component {
 		const confirmPassInputId = 'loginConfirmNewPassword';
 
 		return (
-			<form {...props} onSubmit={this.submit} action="javascript:">
+			<form {...props} onSubmit={this.submit} action="javascript:" method="POST">
 				<label for={newPassInputId}><Text id="loginScreen.labels.newPass" /></label>
 				<PasswordInput
 					autofocus


### PR DESCRIPTION
Add method="POST" to login forms so password managers (e.g. LastPass) won't classify our login and password reset forms as "insecure".  They seem to assume that we are making a GET request and thus will send creds in the clear and warn if we don't specify the method as POST, even though we never submit it because it is all handled in the javascript action.